### PR TITLE
session管理の見直し

### DIFF
--- a/src/app/_hooks/useFetchMonsters.ts
+++ b/src/app/_hooks/useFetchMonsters.ts
@@ -6,51 +6,52 @@ import { CreateMonsterResponseBody } from "../_types/monsters";
 import { api } from "../_utils/api";
 import toast from "react-hot-toast";
 
+type Options = {
+  enabled?: boolean;
+};
+
 const fetchMonstersWithImages = async (): Promise<{
   monsters: CreateMonsterResponseBody[];
   imageUrls: { [key: string]: string };
 }> => {
   // ログイン状態の確認
-  const session = supabase.auth.getSession();
-  if (!session) {
+  const { data: sessionData } = await supabase.auth.getSession();
+  if (!sessionData.session) {
     throw new Error("ログインしてください。");
   }
 
-  try {
-    const res = await api.get<{ monstersView: CreateMonsterResponseBody[] }>(
-      "/api/monster"
-    );
+  const res = await api.get<{ monstersView: CreateMonsterResponseBody[] }>(
+    "/api/monster"
+  );
 
-    if (!res?.monstersView) throw new Error("モンスターの取得に失敗");
-
-    const imageUrls: { [key: string]: string } = {};
-    for (const monster of res.monstersView) {
-      const { data: signedUrlData } = await supabase.storage
-        .from("post-monster")
-        .createSignedUrl(monster.thumbnailImageKey, 60 * 60 * 24);
-      if (signedUrlData?.signedUrl) {
-        imageUrls[monster.thumbnailImageKey] = signedUrlData.signedUrl;
-      }
-    }
-
-    return {
-      monsters: res.monstersView,
-      imageUrls,
-    };
-  } catch (error) {
-    console.error("fetchMonstersWithImages関数でエラー発生:", error);
-    throw error; // 再スローしてSWRで拾えるようにする
+  if (!res?.monstersView) {
+    throw new Error("モンスターの取得に失敗");
   }
+
+  const imageUrls: { [key: string]: string } = {};
+  for (const monster of res.monstersView) {
+    const { data: signedUrlData } = await supabase.storage
+      .from("post-monster")
+      .createSignedUrl(monster.thumbnailImageKey, 60 * 60 * 24);
+
+    if (signedUrlData?.signedUrl) {
+      imageUrls[monster.thumbnailImageKey] = signedUrlData.signedUrl;
+    }
+  }
+
+  return {
+    monsters: res.monstersView,
+    imageUrls,
+  };
 };
 
-export const useFetchMonsters = () => {
+export const useFetchMonsters = (options?: Options) => {
   const { data, error, isLoading, mutate } = useSWR(
-    "/api/monster",
+    options?.enabled !== false ? "/api/monster" : null, // enabled: falseならSWR無効
     fetchMonstersWithImages,
     {
       onError: (error) => {
         console.error("SWRでエラー発生:", error);
-        // エラーがログインエラーの場合の追加処理
         if (error.message === "ログインしてください。") {
           toast.error("ログインしてください");
         }
@@ -63,7 +64,7 @@ export const useFetchMonsters = () => {
     imageUrls: data?.imageUrls ?? {},
     isLoading,
     error,
-    mutate, // 手動で再取得したい時に使う
+    mutate,
   };
 };
 

--- a/src/app/_types/users.ts
+++ b/src/app/_types/users.ts
@@ -15,3 +15,9 @@ export interface SignUpForm {
   email: string;
   password: string;
 }
+
+export interface LoginForm {
+  userName?: string;
+  email: string;
+  password: string;
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,22 +5,15 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { loginSchema } from "../_utils/validationSchema";
 import { supabase } from "../_utils/supabase";
-import { api } from "../_utils/api";
 import { useRouter } from "next/navigation";
 import toast, { Toaster } from "react-hot-toast";
 import { Header } from "../_components/Header";
 import PasswordInput from "../_components/PasswordInput";
 import { Session } from "@supabase/supabase-js";
 import Loading from "../loading";
-// import { useAuthRedirect } from "../_hooks/useAuthRedirect ";
+import { LoginForm } from "../_types/users";
 
-interface LoginForm {
-  userName?: string;
-  email: string;
-  password: string;
-}
 const Page = () => {
-  // useAuthRedirect();
   const router = useRouter();
   const {
     register,
@@ -32,7 +25,7 @@ const Page = () => {
   });
 
   const [session, setSession] = useState<Session | null | undefined>(undefined);
-
+  //  // ログイン状態の確認
   useEffect(() => {
     const checkSession = async () => {
       const {
@@ -56,8 +49,6 @@ const Page = () => {
     return <Loading />;
   }
 
-  //
-
   const onSubmit = async (data: LoginForm) => {
     try {
       const { email, password } = data;
@@ -73,7 +64,7 @@ const Page = () => {
         }
         throw new Error(error.message);
       }
-      await api.post("/api/users", { data });
+
       router.push("/me");
     } catch (error) {
       console.error("Login failed:", error);
@@ -82,11 +73,11 @@ const Page = () => {
       });
     }
   };
+
   return (
     <div className=" min-h-screen">
       <Header />
       <h2 className="text-white text-center text-[24px] py-12">ログイン</h2>
-
       <form
         onSubmit={handleSubmit(onSubmit)}
         className="bg-white w-[85%] mx-auto p-8 rounded-3xl"

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -31,7 +31,7 @@ const Page = () => {
         emailRedirectTo: `${process.env.NEXT_PUBLIC_APP_BASE_URL}/login`,
       },
     });
-
+    console.log(`${process.env.NEXT_PUBLIC_APP_BASE_URL}/login`);
     if (error) {
       toast("登録に失敗", {
         icon: "😭",


### PR DESCRIPTION
タマネギさんからご教授いただいた！
●流れ
①サインアップ→②メールが送られる→③メールからログイン（ここでは/me/page.tsxにリダイレクトのみ）→④/me/page.tsx遷移後新規ユーザーならuserレコード登録。
※メールのリンクから遷移した先は/me/page.tsxページ（session情報がある場合は/me/page.tsxに飛ぶことをlogin/page.tsxに明記）

また、session情報がある時（リダイレクト時）のログインページのちらつきを解消。 
if (session) {
    router.replace("/me");
    return <Loading />;　←ここをつけ足すことで、下のコードを読み込まないようにできた。
  }
